### PR TITLE
systemd: Be consistent and complete in excluding virtual NICs

### DIFF
--- a/systemd/network/yy-pxe.network
+++ b/systemd/network/yy-pxe.network
@@ -1,7 +1,7 @@
 [Match]
-Name=*
-Type=!loopback bridge tunnel vxlan wireguard
-Driver=!veth dummy
+# Only virtual NICs have a Kind, and we want to exclude those.
+Kind=!?*
+Type=!loopback
 KernelCommandLine=!root
 
 [Network]
@@ -10,6 +10,6 @@ KeepConfiguration=dynamic-on-stop
 IPv6AcceptRA=true
 
 [DHCP]
-ClientIdentifier=mac
 UseMTU=true
 UseDomains=true
+ClientIdentifier=mac

--- a/systemd/network/yy-pxe.network
+++ b/systemd/network/yy-pxe.network
@@ -6,7 +6,7 @@ KernelCommandLine=!root
 
 [Network]
 DHCP=yes
-KeepConfiguration=dhcp-on-stop
+KeepConfiguration=dynamic-on-stop
 IPv6AcceptRA=true
 
 [DHCP]

--- a/systemd/network/yy-vmware.network
+++ b/systemd/network/yy-vmware.network
@@ -5,7 +5,7 @@ Driver=!veth
 
 [Network]
 DHCP=yes
-KeepConfiguration=dhcp-on-stop
+KeepConfiguration=dynamic-on-stop
 IPv6AcceptRA=true
 
 [DHCP]

--- a/systemd/network/yy-vmware.network
+++ b/systemd/network/yy-vmware.network
@@ -1,7 +1,8 @@
 [Match]
+# Only virtual NICs have a Kind, and we want to exclude those.
+Kind=!?*
+Type=!loopback
 Virtualization=vmware
-Type=!loopback dummy bridge tunnel vxlan wireguard
-Driver=!veth
 
 [Network]
 DHCP=yes

--- a/systemd/network/zz-default.network
+++ b/systemd/network/zz-default.network
@@ -1,13 +1,12 @@
+[Match]
+# Only virtual NICs have a Kind, and we want to exclude those.
+Kind=!?*
+Type=!loopback
+
 [Network]
 DHCP=yes
 KeepConfiguration=dynamic-on-stop
 IPv6AcceptRA=true
-
-[Match]
-Name=*
-Type=!loopback bridge tunnel vxlan wireguard
-Driver=!veth tun dummy
-Kind=!tun bridge gre veth wireguard
 
 [DHCP]
 UseMTU=true

--- a/systemd/network/zz-default.network
+++ b/systemd/network/zz-default.network
@@ -1,6 +1,6 @@
 [Network]
 DHCP=yes
-KeepConfiguration=dhcp-on-stop
+KeepConfiguration=dynamic-on-stop
 IPv6AcceptRA=true
 
 [Match]

--- a/systemd/system/oem-cloudinit.service
+++ b/systemd/system/oem-cloudinit.service
@@ -4,8 +4,8 @@ Description=Run cloudinit
 [Service]
 EnvironmentFile=/var/run/ignition.env
 Type=oneshot
-ExecCondition=/usr/bin/bash -xc 'OEMS=(aws gcp azure cloudsigma vmware digitalocean openstack); echo $${OEMS[*]} | tr " " "\n" | grep -q -x -F "${OEM_ID}"'
-ExecStart=/usr/bin/bash -xc '/usr/bin/coreos-cloudinit --oem="$(if [ "${OEM_ID}" = aws -o "${OEM_ID}" = openstack ]; then echo ec2-compat; elif [ "${OEM_ID}" = gcp ]; then echo gce; else echo "${OEM_ID}" ; fi)"'
+ExecCondition=bash -xc 'case ${OEM_ID} in aws|azure|cloudsigma|digitalocean|gcp|openstack|vmware) true;; *) false;; esac'
+ExecStart=bash -xc 'exec coreos-cloudinit --oem="$(case ${OEM_ID} in aws|openstack) echo ec2-compat;; gcp) echo gce;; *) printf "%s" "${OEM_ID}";; esac)"'
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Only virtual NICs have a `Kind`, so just exclude all of them by wildcard instead of explicitly naming them. systemd.netdev(5) says there are currently 37 of them! These include the `Driver`s and `Type`s we were previously excluding, apart from `loopback`.

Also replace the legacy `KeepConfiguration=dhcp-on-stop` with `dynamic-on-stop` and make oem-cloudinit.service a bit less ugly.

Tested in CI and manually with QEMU and Proxmox.